### PR TITLE
:recycle: Move constants to mapply module, tqdm with ETA when possible

### DIFF
--- a/src/mapply/__init__.py
+++ b/src/mapply/__init__.py
@@ -20,8 +20,8 @@ Example usage:
 from functools import partialmethod
 
 from mapply._version import version as __version__  # noqa:F401
+from mapply.mapply import DEFAULT_CHUNK_SIZE, DEFAULT_MAX_CHUNKS_PER_WORKER
 from mapply.mapply import mapply as _mapply
-from mapply.parallel import DEFAULT_CHUNK_SIZE, DEFAULT_MAX_CHUNKS_PER_WORKER
 
 
 def init(

--- a/src/mapply/mapply.py
+++ b/src/mapply/mapply.py
@@ -13,12 +13,10 @@ Standalone usage (without init):
 from functools import partial
 from typing import Any, Callable, Tuple, Union
 
-from mapply.parallel import (
-    DEFAULT_CHUNK_SIZE,
-    DEFAULT_MAX_CHUNKS_PER_WORKER,
-    N_CORES,
-    multiprocessing_imap,
-)
+from mapply.parallel import N_CORES, multiprocessing_imap
+
+DEFAULT_CHUNK_SIZE = 100
+DEFAULT_MAX_CHUNKS_PER_WORKER = 8
 
 
 def _choose_n_chunks(

--- a/src/mapply/parallel.py
+++ b/src/mapply/parallel.py
@@ -22,9 +22,11 @@ from typing import Any, Callable, Iterable, List, Optional
 
 import psutil
 from pathos.multiprocessing import ProcessPool
-from tqdm.auto import tqdm
+from tqdm.auto import tqdm as _tqdm
 
 logger = logging.getLogger(__name__)
+
+tqdm = partial(_tqdm, dynamic_ncols=True)
 
 
 def sensible_cpu_count() -> int:
@@ -33,8 +35,6 @@ def sensible_cpu_count() -> int:
 
 
 N_CORES = sensible_cpu_count()
-DEFAULT_CHUNK_SIZE = 100
-DEFAULT_MAX_CHUNKS_PER_WORKER = 8
 
 
 def _choose_n_workers(n_chunks: Optional[int], n_workers: int) -> int:
@@ -93,7 +93,7 @@ def multiprocessing_imap(
         stage = pool.imap(func, iterable)
 
     if progressbar:
-        stage = tqdm(stage)
+        stage = tqdm(stage, total=n_chunks)
 
     try:
         return list(stage)


### PR DESCRIPTION
Triggered by #8 

- When length (or shape) of iterable is known, pass it to tqdm explicitly (because imap swallows it). This ensures an ETA based on moving average is printed during execution, and allows for an actual animated progress bar to be printed.
- Add `dynamic_ncols=True` to the tqdm, such that terminal windows can be resized (and full width of notebook is utilized).
- Move some constants to mapply module, where they belong 