### PR TITLE
:zap: Speed up multiprocessing by using map when iterable length is known

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ ignore = D10,E203,E501,W503
 max-line-length = 88
 inline-quotes = double
 docstring-convention = google
-max-cognitive-complexity = 10
+max-cognitive-complexity = 12
 
 [coverage:run]
 branch = True

--- a/src/mapply/parallel.py
+++ b/src/mapply/parallel.py
@@ -94,7 +94,12 @@ def multiprocessing_imap(
         logger.debug("Starting ProcessPool with %d workers", n_workers)
         pool = ProcessPool(n_workers)
 
-        stage = pool.imap(func, iterable)
+        if n_chunks is None:
+            # iterable hasn't been exhausted yet, let imap exhaust it
+            stage = pool.imap(func, iterable)
+        else:
+            # no need for imap, can use (mostly) faster map
+            stage = pool.map(func, iterable)
 
     if progressbar:
         stage = tqdm(stage, total=n_chunks)


### PR DESCRIPTION
ref https://github.com/uqfoundation/multiprocess/blob/multiprocess-0.70.12.2/py3.10/multiprocess/pool.py#L395