### PR TITLE
:sparkles: Introduce maxtasksperchild to increase stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### mapply vs. pandarallel vs. swifter
 
-Where [`pandarallel`](https://github.com/nalepae/pandarallel) only requires [`dill`](https://github.com/uqfoundation/dill) (and therefore has to rely on in-house multiprocessing and progressbars), [`swifter`](https://github.com/jmcarpenter2/swifter) relies on the heavy [`dask`](https://github.com/dask/dask) framework, converting to Dask DataFrames and back. In an attempt to find the golden mean, `mapply` is highly customizable and remains lightweight, leveraging the powerful [`pathos`](https://github.com/uqfoundation/pathos) framework, which shadows Python's built-in multiprocessing module using `dill` for universal pickling.
+Where [`pandarallel`](https://github.com/nalepae/pandarallel) only requires [`dill`](https://github.com/uqfoundation/dill) (and therefore has to rely on in-house multiprocessing and progressbars), [`swifter`](https://github.com/jmcarpenter2/swifter) relies on the heavy [`dask`](https://github.com/dask/dask) framework, converting to Dask DataFrames and back. In an attempt to find the golden mean, `mapply` is highly customizable and remains lightweight, leveraging [`tqdm`](https://github.com/tqdm/tqdm) and [`multiprocess`](https://github.com/uqfoundation/multiprocess), which shadows Python's built-in multiprocessing module using [`dill`](https://github.com/uqfoundation/dill) for universal pickling.
 
 
 ## Installation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,6 +181,6 @@ def linkcode_resolve(  # noqa:CCR001
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "pathos": ("https://pathos.readthedocs.io/en/latest", None),
+    "multiprocess": ("https://multiprocess.readthedocs.io/en/latest/", None),
     # "tqdm": ("https://tqdm.github.io/docs/tqdm", None),  # mkdocs not working
 }

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,3 @@
-pathos>=0.2.0
+multiprocess
 psutil
 tqdm>=4.27  # from tqdm.auto import tqdm


### PR DESCRIPTION
Long iterators would see some workers hang over time, essentially https://stackoverflow.com/q/45447947

This PR:
- Introduces MAPPLY_MAX_TASKS_PER_CHILD env var, defaulting to 4.
- Replaces dependency on `pathos` with lower level `multiprocess`.
