### PR TITLE
:zap: Avoid bottleneck from frequent tqdm updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements/*.txt') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements/*.txt') }}
 
     - name: Pre-commit cache
       uses: actions/cache@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
             'flake8-blind-except~=0.2.1',
             'flake8-builtins~=2.0',  # last version to support py3.6
             'flake8-cognitive-complexity==0.1.0',
-            'flake8-comprehensions~=3.10.0',
+            'flake8-comprehensions~=3.7',  # last version to support py3.6
             'flake8-docstrings~=1.6.0',
             'flake8-logging-format~=0.8.1',
             'flake8-mutable~=1.2.0',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
             'flake8-docstrings~=1.6.0',
             'flake8-logging-format~=0.8.1',
             'flake8-mutable~=1.2.0',
-            'flake8-print~=5.0.0',
+            'flake8-print~=4.0',  # last version to support py3.6
             'flake8-printf-formatting~=1.1.0',
             'flake8-pytest-style~=1.6.0',
             'flake8-quotes~=3.3.1',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
             'darglint~=1.8.1',
             'flake8-absolute-import~=1.0',
             'flake8-blind-except~=0.2.1',
-            'flake8-builtins~=2.0.1',
+            'flake8-builtins~=2.0',  # last version to support py3.6
             'flake8-cognitive-complexity==0.1.0',
             'flake8-comprehensions~=3.10.0',
             'flake8-docstrings~=1.6.0',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         exclude: .*/tests/.*
 
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.8.0 # last version to support py3.6 ref https://github.com/psf/black/issues/3169#issuecomment-1303315799
     hooks:
     -   id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.14.3
+    rev: v1.4.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: .*/tests/.*
 
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
     -   id: black
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.5.4
+    rev: 5.10.1
     hooks:
     -   id: isort
 
@@ -26,29 +26,29 @@ repos:
         pass_filenames: false
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
     -   id: flake8
         additional_dependencies: [
-            'darglint~=1.5.4',
+            'darglint~=1.8.1',
             'flake8-absolute-import~=1.0',
-            'flake8-blind-except~=0.1.1',
-            'flake8-builtins~=1.5.3',
+            'flake8-blind-except~=0.2.1',
+            'flake8-builtins~=2.0.1',
             'flake8-cognitive-complexity==0.1.0',
-            'flake8-comprehensions~=3.2.3',
-            'flake8-docstrings~=1.5.0',
-            'flake8-logging-format~=0.6.0',
+            'flake8-comprehensions~=3.10.0',
+            'flake8-docstrings~=1.6.0',
+            'flake8-logging-format~=0.8.1',
             'flake8-mutable~=1.2.0',
-            'flake8-print~=3.1.4',
+            'flake8-print~=5.0.0',
             'flake8-printf-formatting~=1.1.0',
-            'flake8-pytest-style~=1.2.3',
-            'flake8-quotes~=3.2.0',
+            'flake8-pytest-style~=1.6.0',
+            'flake8-quotes~=3.3.1',
             'flake8-tuple~=0.4.1',
-            'pep8-naming~=0.11.1'
+            'pep8-naming~=0.13.2'
         ]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
     -   id: mixed-line-ending
         args: ['--fix=lf']
@@ -62,7 +62,7 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/econchick/interrogate
-    rev: 1.3.1
+    rev: 1.5.0
     hooks:
       - id: interrogate
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
             'flake8-pytest-style~=1.6.0',
             'flake8-quotes~=3.3.1',
             'flake8-tuple~=0.4.1',
-            'pep8-naming~=0.13.2'
+            'pep8-naming~=0.13.1'  # last version to support py3.6
         ]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         ]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.1.0  # last version to support py3.6
     hooks:
     -   id: mixed-line-ending
         args: ['--fix=lf']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         pass_filenames: false
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 4.0.1  # flake8-comprehensions 3.7.0 depends on flake8!=3.2.0, <5 and >=3.0
     hooks:
     -   id: flake8
         additional_dependencies: [

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ default_section = THIRDPARTY
 known_first_party = tests
 
 [flake8]
-ignore = D10,E203,E501,W503
+ignore = B902,D10,E203,E501,W503
 max-line-length = 88
 inline-quotes = double
 docstring-convention = google

--- a/src/mapply/parallel.py
+++ b/src/mapply/parallel.py
@@ -29,7 +29,7 @@ from tqdm.auto import tqdm as _tqdm
 
 logger = logging.getLogger(__name__)
 
-tqdm = partial(_tqdm, dynamic_ncols=True)
+tqdm = partial(_tqdm, dynamic_ncols=True, smoothing=0.042, mininterval=0.42)
 
 
 def sensible_cpu_count() -> int:


### PR DESCRIPTION
When chunks take very little time, things get slowed down when tqdm sends many updates per second (especially to a remote jupyter notebook).