### PR TITLE
:children_crossing: Add MAPPLY_START_METHOD environment variable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     additional_dependencies: ['gibberish-detector']
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.6
+  rev: v0.1.8
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -41,6 +41,7 @@ repos:
   rev: v0.23.1
   hooks:
   - id: toml-sort-fix
+    args: ['--trailing-comma-inline-array']
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,15 +57,14 @@ ignore = [
   "TRY003", # there is EM102
   "D203", # there is D211
   "D213", # there is D212
-  "FIX002" # there is TD002,TD003
+  "FIX002", # there is TD002,TD003
 ]
 
 [tool.ruff.extend-per-file-ignores]
-"__init__.py" = ["E401", "E402"]
 "**/tests/**/*.py" = [
   "S101", # assert is fine in tests
   "D100", # tests is not a package
-  "D104" # tests modules don't need docstrings
+  "D104", # tests modules don't need docstrings
 ]
 
 [tool.ruff.isort]

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
-pathos>=0.2.0
+pathos>=0.3.1  # https://github.com/uqfoundation/pathos/pull/252
+multiprocess
 psutil
 tqdm>=4.27  # from tqdm.auto import tqdm


### PR DESCRIPTION
fix #42, fix #58 

- the `multiprocess` default start method is `fork` on linux and macos, deviating from `multiprocessing` defaults.
- as stated in python docs, `fork` is unstable for multithreaded code, and joining the forked subprocesses might hang.
- for anyone experiencing hanging applies, run `export MAPPLY_START_METHOD=spawn` or `export MAPPLY_START_METHOD=forkserver` before starting the program. or in a jupyter cell before importing mapply: `%env MY_VAR=MY_VALUE`