### PR TITLE
:pushpin: Require pandas~=2.1 and drop support for python 3.8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ ignore = [
   "D203", # there is D211
   "D213", # there is D212
   "FIX002", # there is TD002,TD003
+  "TCH003", # clutters
 ]
 
 [tool.ruff.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Sensible multi-core apply function for Pandas"
 readme = "README.md"
 urls = {Repository = "https://github.com/ddelange/mapply", Documentation = "https://mapply.readthedocs.io"}
 authors = [{name = "ddelange", email = "ddelange@delange.dev"}]
-requires-python = ">=3.8" # sync with classifiers below, and tool.ruff and tool.mypy
+requires-python = ">=3.9" # sync with classifiers below, and tool.ruff and tool.mypy
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -16,7 +16,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -31,7 +30,7 @@ branch = true
 omit = ["site-packages"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 ignore_missing_imports = true
 warn_no_return = false
 disallow_untyped_defs = false

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -3,4 +3,3 @@ mypy~=1.6
 pre-commit~=3.5
 pytest-cov~=4.1
 pytest~=7.4
-pandas

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,3 +2,4 @@ pathos>=0.3.1  # https://github.com/uqfoundation/pathos/pull/252
 multiprocess
 psutil
 tqdm>=4.27  # from tqdm.auto import tqdm
+pandas~=2.1

--- a/src/mapply/_groupby.py
+++ b/src/mapply/_groupby.py
@@ -33,7 +33,7 @@
 # ruff: noqa: ERA001
 import logging
 from types import MethodType
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 from mapply.parallel import multiprocessing_imap, tqdm
 
@@ -46,7 +46,7 @@ def run_groupwise_apply(
     *,
     n_workers: int,
     progressbar: bool,
-    args: Tuple[Any, ...] = (),  # noqa: FA100
+    args: tuple[Any, ...] = (),
     **kwargs: Any,
 ):
     """Patch GroupBy.grouper.apply, applying func to each group in parallel."""

--- a/src/mapply/_groupby.py
+++ b/src/mapply/_groupby.py
@@ -50,7 +50,6 @@ def run_groupwise_apply(
     **kwargs: Any,
 ):
     """Patch GroupBy.grouper.apply, applying func to each group in parallel."""
-    from pandas import __version__
 
     def apply(self, f, data, axis=0):
         # patching https://github.com/pandas-dev/pandas/blob/v1.5.3/pandas/core/groupby/ops.py#L823
@@ -118,13 +117,8 @@ def run_groupwise_apply(
 
         return result_values, mutated
 
-    if __version__.split(".") < ["1", "5"]:  # pragma: no cover
-        logger.warning("GroupBy.mapply only works for pandas>=1.5.0. Using single CPU.")
-        return df_or_series.apply(func, *args, **kwargs)
-
-    # 2.1.0 renamed to apply_groupwise ref https://github.com/pandas-dev/pandas/commit/dc947a459b094ccd087557db355cfde5ed97b454
-    attr = "apply" if hasattr(df_or_series.grouper, "apply") else "apply_groupwise"
     # overwrite apply method and restore after execution
+    attr = "apply_groupwise"
     original_apply = getattr(df_or_series.grouper, attr)
     setattr(df_or_series.grouper, attr, MethodType(apply, df_or_series.grouper))
     try:

--- a/src/mapply/parallel.py
+++ b/src/mapply/parallel.py
@@ -54,8 +54,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable, Iterator
 from functools import partial
-from typing import Any, Callable, Iterable, Iterator
+from typing import Any, Callable
 
 import multiprocess
 import psutil


### PR DESCRIPTION
Pin the supported pandas version range for maintainability